### PR TITLE
Vcsel transitions and upgrade to rydberg_calcs

### DIFF
--- a/models/rydberg_calcs.py
+++ b/models/rydberg_calcs.py
@@ -578,25 +578,3 @@ class RydbergTransition:
 
         print("Saturation Power E (mW)", satPower_E * 1e3)
         print("Saturation Power R (mW)", satPower_R * 1e3)
-
-
-if __name__ == '__main__':
-    transition40 = RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5,
-                                     mj1=0.5, f1=4, q1=1, n2=7, l2=1, j2=1.5,
-                                     mj2=1.5, f2=5,
-                                     q2=-1, n3=40, l3=0, j3=0.5)
-
-    transition40.print_laser_frequencies(Pp=0.010, Pc=2)
-
-    powers = np.linspace(0, 10, 1000)
-    rabiFreqs = [transition40.transition2.RabiAngularFreq_from_Power(p) for p
-                 in powers]
-    powersOut = [transition40.transition2.Power_from_RabiAngularFreq(f) for
-                 f in
-                 rabiFreqs]
-    import matplotlib.pyplot as plt
-    plt.plot(powers, rabiFreqs)
-    plt.plot(powersOut, rabiFreqs)
-    plt.xlabel('Power (W)')
-    plt.ylabel('Rabi Frequency (Hz)')
-    plt.show()

--- a/notebooks/RydbergTuning.ipynb
+++ b/notebooks/RydbergTuning.ipynb
@@ -50,8 +50,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transition47 = ryd.RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5,\n",
-    "                 mj1=0.5, f1=4, n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, n3=47, l3=2, j3=2.5, mj3=1.5, f3=5)\n",
+    "transition47 = ryd.RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q1=1,\n",
+    "                                n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, mf2=5, q2=1,\n",
+    "                                n3=47, l3=2, j3=2.5, mj3=2.5, f3=6, mf3=6)\n",
     "\n",
     "couple_power_balanced = transition47.get_balanced_laser_power(probe_power=probe_power)\n",
     "print(\"1064nm power should be \", couple_power_balanced*1e3, \" mW\")"
@@ -74,8 +75,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transition40 = ryd.RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5,\n",
-    "                 mj1=0.5, n2=7, l2=1, j2=1.5, mj2=1.5, q2=-1, n3=40, l3=0, j3=0.5)\n",
+    "transition40 = ryd.RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q1=1, \n",
+    "                                    n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, mf2=5, q2=-1, \n",
+    "                                    n3=40, l3=0, j3=0.5, mj3=0.5, f3=4, mf3=4)\n",
     "\n",
     "couple_power_balanced = transition40.get_balanced_laser_power(probe_power=probe_power)\n",
     "print(\"1064nm power should be \", couple_power_balanced*1e3, \" mW\")"
@@ -98,8 +100,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transition41 = ryd.RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5,\n",
-    "                 mj1=0.5, n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, q2=-1, n3=41, l3=0, j3=0.5, mj3=0.5, f3=4)\n",
+    "transition41 = ryd.RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q1=1, \n",
+    "                                    n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, mf2=5, q2=-1, \n",
+    "                                    n3=41, l3=0, j3=0.5, mj3=0.5, f3=4, mf3=4)\n",
     "\n",
     "couple_power_balanced = transition41.get_balanced_laser_power(probe_power=probe_power)\n",
     "print(\"1064nm power should be \", couple_power_balanced*1e3, \" mW\")"

--- a/notebooks/VCSEL-Transitions.ipynb
+++ b/notebooks/VCSEL-Transitions.ipynb
@@ -1,0 +1,208 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e902d6d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('../')\n",
+    "%load_ext autotime\n",
+    "import numpy as np\n",
+    "import models.rydberg_calcs as ryd\n",
+    "from scipy.constants import c as C_c\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf7941b4",
+   "metadata": {},
+   "source": [
+    "VCSELs are fundamentally single-mode lasers, due to their large cavity FSR, and typically emit in a single transverse mode (TEM00). They can be modulated directly at very high frequencies, and manufactured in very large and closely-spaced arrays with individually addressable sites. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41340fbe",
+   "metadata": {},
+   "source": [
+    "The gain section of VCSELs is very short, which fundamentally limits their total output power to only a few milliwatts. Let's explore what Rabi frequencies are achievable with few milliwatt powers on the most advantageous transitions in Cs and Rb. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd5f08cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "laserWaist = 25e-6"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "967fa33e",
+   "metadata": {},
+   "source": [
+    "We can possibly juice out a pit more Rabi frequency using very small waists with a microlens array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdd94691",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transition_7P32 = ryd.OpticalTransition(n1=6, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q=1, \n",
+    "                                        n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, mf2=5, laserWaist=laserWaist)\n",
+    "print(transition_7P32.matrixElement)\n",
+    "transition_7P12 = ryd.OpticalTransition(n1=6, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q=-1, \n",
+    "                                        n2=7, l2=1, j2=1.5, mj2=1.5, f2=3, mf2=3, laserWaist=laserWaist)\n",
+    "print(transition_7P12.matrixElement)\n",
+    "transition_6P32 = ryd.OpticalTransition(n1=6, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q=1, \n",
+    "                                        n2=6, l2=1, j2=1.5, mj2=1.5, f2=5, mf2=5, laserWaist=laserWaist)\n",
+    "print(transition_6P32.matrixElement)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1de3c52b",
+   "metadata": {},
+   "source": [
+    "Ground state 6S to 6P3/2 at 852nm is of course a very strong transition, so that's advantageous. What states then connect us up to the Rydberg states?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65bdc1dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transition_6P32_7S12 = ryd.OpticalTransition(n1=6, l1=1, j1=1.5, mj1=1.5, f1=5, mf1=5, q=-1, \n",
+    "                                        n2=7, l2=0, j2=0.5, mj2=0.5, f2=4, mf2=4, laserWaist=laserWaist)\n",
+    "print(C_c/transition_6P32_7S12.get_transition_freq()*1e9, \"nm\")\n",
+    "print(transition_6P32_7S12.matrixElement)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26863a5a",
+   "metadata": {},
+   "source": [
+    "6P3/2 to 7S1/2 is also a very strong transition, at 1470nm (good for diode lasers). How does the coupling to Rabi states compare to 7P3/2 to the Rydberg states?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fd76de1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transition_7S12_40P32 = ryd.OpticalTransition(n1=7, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q=1, \n",
+    "                                        n2=40, l2=1, j2=1.5, mj2=1.5, f2=5, mf2=5, laserWaist=laserWaist)\n",
+    "print(C_c/transition_7S12_40P32.get_transition_freq()*1e9, \"nm\")\n",
+    "print(transition_7S12_40P32.matrixElement)\n",
+    "transition_7P32_40S12 = ryd.OpticalTransition(n1=7, l1=1, j1=1.5, mj1=1.5, f1=5, mf1=5, q=-1, \n",
+    "                                        n2=40, l2=0, j2=0.5, mj2=0.5, f2=4, mf2=4, laserWaist=laserWaist)\n",
+    "print(C_c/transition_7P32_40S12.get_transition_freq()*1e9, \"nm\")\n",
+    "print(transition_7P32_40S12.matrixElement)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b469f3b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the range of n2 values to plot\n",
+    "n2_values = range(20, 61)\n",
+    "\n",
+    "# Lists to store matrix elements for both transitions\n",
+    "matrix_elements_7S12_nP32 = []\n",
+    "matrix_elements_7P32_nS12 = []\n",
+    "wavelengths_7S12_nP32 = []\n",
+    "wavelengths_7P32_nS12 = []\n",
+    "\n",
+    "# Calculate matrix elements for each n2 value\n",
+    "for n2 in n2_values:\n",
+    "    # First transition: 7S1/2 to nP3/2\n",
+    "    transition_7S12_nP32 = ryd.OpticalTransition(\n",
+    "        n1=7, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q=1,\n",
+    "        n2=n2, l2=1, j2=1.5, mj2=1.5, f2=5, mf2=5, laserWaist=laserWaist\n",
+    "    )\n",
+    "    matrix_elements_7S12_nP32.append(transition_7S12_nP32.matrixElement)\n",
+    "    wavelengths_7S12_nP32.append(C_c/transition_7S12_nP32.get_transition_freq()*1e9)\n",
+    "    \n",
+    "    # Second transition: 7P3/2 to nS1/2\n",
+    "    transition_7P32_nS12 = ryd.OpticalTransition(\n",
+    "        n1=7, l1=1, j1=1.5, mj1=1.5, f1=5, mf1=5, q=-1,\n",
+    "        n2=n2, l2=0, j2=0.5, mj2=0.5, f2=4, mf2=4, laserWaist=laserWaist\n",
+    "    )\n",
+    "    matrix_elements_7P32_nS12.append(transition_7P32_nS12.matrixElement)\n",
+    "    wavelengths_7P32_nS12.append(C_c/transition_7P32_nS12.get_transition_freq()*1e9)\n",
+    "\n",
+    "# Create the figure with two subplots\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))\n",
+    "\n",
+    "# Plot matrix elements vs n2\n",
+    "ax1.plot(n2_values, np.abs(matrix_elements_7S12_nP32), 'o-', label='7S1/2 → nP3/2')\n",
+    "ax1.plot(n2_values, np.abs(matrix_elements_7P32_nS12), 's-', label='7P3/2 → nS1/2')\n",
+    "ax1.set_xlabel('Principal Quantum Number (n2)')\n",
+    "ax1.set_ylabel('abs(Matrix Element)')\n",
+    "ax1.set_title('Matrix Element vs Principal Quantum Number')\n",
+    "ax1.legend()\n",
+    "ax1.grid(True)\n",
+    "\n",
+    "# Plot wavelengths vs n2\n",
+    "ax2.plot(n2_values, wavelengths_7S12_nP32, 'o-', label='7S1/2 → nP3/2')\n",
+    "ax2.plot(n2_values, wavelengths_7P32_nS12, 's-', label='7P3/2 → nS1/2')\n",
+    "ax2.set_xlabel('Principal Quantum Number (n2)')\n",
+    "ax2.set_ylabel('Wavelength (nm)')\n",
+    "ax2.set_title('Transition Wavelength vs Principal Quantum Number')\n",
+    "ax2.legend()\n",
+    "ax2.grid(True)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ebce856",
+   "metadata": {},
+   "source": [
+    "It appears that the 7P3/2 to nS1/2 transition is always stronger than the 7S1/2 to nP3/2 transition, but only by a factor of ~2.8, not that much. The wavelength for 7P3/2 to nS1/2 is favorable, around 780nm. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5a6c6bd",
+   "metadata": {},
+   "source": [
+    "How do pulse programs in a 4-level system achieve optimal population inversion? This is a question we should address via an optimization program."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c1d563",
+   "metadata": {},
+   "source": [
+    "Are there any advantages to using Rb instead?"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plotters/plot_rydberg_dynamics.py
+++ b/plotters/plot_rydberg_dynamics.py
@@ -773,5 +773,5 @@ def plot_lindblad_duo_pulse_spectrum(probe_duration: float = 0, probe_delay: flo
 
 if __name__ == '__main__':
     #plot_rho_dynamics()
-    #plot_lindblad_dynamics()
-    plot_state_vs_probe_duration()
+    plot_lindblad_dynamics()
+    #plot_state_vs_probe_duration()

--- a/tests/test_rydberg_calcs.py
+++ b/tests/test_rydberg_calcs.py
@@ -14,10 +14,12 @@ def test_transition_frequencies_n47_n41():
     transitions to n=47 and n=41 Rydberg states.
     """
     # Initialize transitions
-    n47_transition = RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5,
-                 mj1=0.5, f1=4, n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, n3=47, l3=2, j3=2.5, mj3=1.5, f3=5)
-    n41_transition = RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5,
-                 mj1=0.5, n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, q2=-1, n3=41, l3=0, j3=0.5, mj3=0.5, f3=4)
+    n47_transition = RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q1=1,
+                                        n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, mf2=5, q2=1,
+                                        n3=47, l3=2, j3=2.5, mj3=2.5, f3=6, mf3=6)
+    n41_transition = RydbergTransition(laserWaist=25e-6, n1=6, l1=0, j1=0.5, mj1=0.5, f1=4, mf1=4, q1=1,
+                                        n2=7, l2=1, j2=1.5, mj2=1.5, f2=5, mf2=5, q2=-1,
+                                        n3=41, l3=0, j3=0.5, mj3=0.5, f3=4, mf3=4)
 
     # n=47 transition frequencies
     trans1_47 = n47_transition.transition1.get_transition_freq()


### PR DESCRIPTION
Upgraded computation of rabi frequencies to use matrix element for transition, initiated once at object creation. Matrix element computation attempts to use HFS matrix element, if available, by default. Updated dependencies and test. Made short notebook to compare matrix elements of VCSEL compatible transitions. 